### PR TITLE
Get and init SDK separately from the bundle.

### DIFF
--- a/packages/extension/public/index.html
+++ b/packages/extension/public/index.html
@@ -9,6 +9,26 @@
       name="description"
       content="Web site created using create-react-app"
     />
+
+    <script>
+      function initialize() {
+        // Initialize the SDK before the bundle loads, so that DC knows we're an extension and doesn't time out.
+  
+        window.extensionsSdkInstance = new Promise((resolve, reject) => {
+          let script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.onload = () => {
+            dcExtensionsSdk.init().then(result => resolve(result)).catch(error => reject(error));
+          }
+    
+          script.src = 'https://unpkg.com/dc-extensions-sdk@1.0.3/dist/dc-extensions-sdk.umd.js';
+          document.head.appendChild(script);
+        });
+      }
+  
+      initialize();
+    </script>
+
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/packages/extension/src/App.tsx
+++ b/packages/extension/src/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { init, SDK } from "dc-extensions-sdk";
+import { SDK } from "dc-extensions-sdk";
 import { SdkContext, withTheme } from "unofficial-dynamic-content-ui";
 import EditorRichTextField from "./EditorRichTextField/EditorRichTextField";
 import { RichTextDialogsContainer } from "./RichTextDialogs";
@@ -24,7 +24,10 @@ export default class App extends React.Component<{}, AppState> {
   }
 
   public async handleConnect(): Promise<void> {
-    const sdk: SDK = await init();
+    // See index.html for sdk init. 
+    // Doing it there avoids DC timing us out for taking too long to respond, if this bundle takes too long to load.
+    // tslint:disable-next-line: no-string-literal
+    const sdk = await ((window as any).extensionsSdkInstance as Promise<SDK>);
     sdk.frame.startAutoResizer();
 
     const value: any = await sdk.field.getValue();


### PR DESCRIPTION
Right now, DC starts a timeout from when it creates the extension iframe, which falls back to the more generic content editor when the extension doesn't load in time. This is good if the server is down, however, we're seeing this crop up when using slow internet connections in a few extensions, since _the sdk will only init after the full bundle is loaded_. Since extensions will inevitably be built using modern web frameworks + webpack, this is an inevitable issue with pretty much all of our existing extensions, regardless of their level of optimization...

The solution is as follows:

- Load the extensions SDK directly in the index.html, and init as soon as it loads.
  - This is done in a `<script>` tag, as linking a separate js file usually doubles the latency, which could be bad on slow cellular data.
    - Could be solved by making the script version of the SDK load and init itself, but that's not in the scope of this project.
  - A specific version of the extensions sdk is loaded rather than the general url. Waiting for the redirect and requesting again was doubling the latency to get the script.
- Store a promise to get the inited sdk in the `window` object, using a relatively safe name.
  - Note: this promise exists even before the sdk js loads, to ensure that nothing bad happens if the bundle somehow loads before the sdk. 
  - The promise will wait if the sdk is not present or init is not complete, and return the sdk after it is.
- In place of where we init the sdk before, await the promise created on the window object for the inited sdk.

This is just one iteration of a few extensions I've changed to use this behaviour. Let me know if there's a better way to do it.